### PR TITLE
Element UI tags with autocomplete 

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@babel/core": "7.0.0",
     "@babel/register": "7.0.0",
-    "@voerro/vue-tagsinput": "^2.1.0",
     "@vue/cli-plugin-babel": "3.6.0",
     "@vue/cli-plugin-eslint": "^3.9.1",
     "@vue/cli-plugin-unit-jest": "3.6.3",

--- a/front-end/src/api/existingTags.js
+++ b/front-end/src/api/existingTags.js
@@ -5,10 +5,5 @@ export function getExistingTags(params) {
     url: '/dms/tags/',
     method: 'get',
     params
-  }).then(response => {
-      return response.data.map(tag => ({
-          key: tag,
-          value: tag,
-      }))
   })
 }

--- a/front-end/src/components/AddModalWindow/AddModalWindow.vue
+++ b/front-end/src/components/AddModalWindow/AddModalWindow.vue
@@ -195,9 +195,7 @@
 
                     formData.append('category', this.form.currentCategory);
 
-                    for (const tag of this.$refs.tagsInput.selected) {
-                      formData.append('tags', tag);
-                    }
+                    this.$refs.tagsInput.selected.forEach(tag => formData.append('tags', tag));
 
                     if (this.form.fileList.length !== 0) {
                         formData.append('content', this.form.fileList[0].raw);

--- a/front-end/src/components/AddModalWindow/AddModalWindow.vue
+++ b/front-end/src/components/AddModalWindow/AddModalWindow.vue
@@ -90,16 +90,7 @@
                 </el-select>
             </el-form-item>
 
-            <el-form-item label="Ключевые слова">
-                <tags-input element-id="tags"
-                            v-model="form.selectedTags"
-                            :existing-tags="existingTags"
-                            :typeahead="true"
-                            placeholder="Добавить ключевое слово"
-                            :typeahead-hide-discard="true"
-                            class="add-tags">
-                </tags-input>
-            </el-form-item>
+            <TagsInput ref="tagsInput" label="Ключевые слова" />
 
 <!--            <el-form-item>-->
 <!--                <div class="add-files">-->
@@ -145,16 +136,15 @@
 </template>
 
 <script>
-    import {getExistingTags} from "../../api/existingTags";
-    import axios from "axios";
     import moment from 'moment'
     import EventBus from '../EventBus';
-    import {uploadDocs} from "../../api/upload";
+    import {uploadDocs} from "@/api/upload";
     import {mapState} from "vuex";
-
+    import TagsInput from "@/components/Tags/TagsInput";
 
     export default {
         name: "AddModalWindow",
+        components: {TagsInput},
         data() {
             return {
                 form: {
@@ -168,20 +158,11 @@
                     newAuthorPatronymic: '',
                     publisher: '',
                     newPublisher: '',
-                    selectedTags: [],
                     fileList: [],
                     currentCategory: ''
                 },
-                existingTags: [
-                    { key: 1, value: 'Стратегия' },
-                    { key: 2, value: 'Тактика' },
-                    { key: 3, value: 'Хуяктика' },
-                ],
                 publishers: [{name: 'Добавить новое', id: -1}, ...this.$store.getters.publishers],
             }
-        },
-        created() {
-            this.fetchData()
         },
         updated() {
             // console.log(this.form.fileList)
@@ -193,14 +174,6 @@
             })
         },
         methods: {
-            fetchData() {
-                getExistingTags()
-                    .then(tags => {
-                        this.existingTags = tags
-                    }).catch(() => {
-                        console.log('Данные по тегам не указаны')
-                    })
-            },
             onSubmit() {
                 const self = this
                 if (this.form.title !== '' && this.form.currentCategory !== '') {
@@ -222,7 +195,7 @@
 
                     formData.append('category', this.form.currentCategory);
 
-                    for (const tag of this.form.selectedTags.map(tag => tag.value)) {
+                    for (const tag of this.$refs.tagsInput.selected) {
                       formData.append('tags', tag);
                     }
 
@@ -271,21 +244,5 @@
 </script>
 
 <style scoped lang="scss">
-    @import "style.scss";
-
-    .el-tag + .el-tag {
-        margin-left: 10px;
-    }
-    .button-new-tag {
-        margin-left: 10px;
-        height: 32px;
-        line-height: 30px;
-        padding-top: 0;
-        padding-bottom: 0;
-    }
-    .input-new-tag {
-        width: 90px;
-        margin-left: 10px;
-        vertical-align: bottom;
-    }
+@import "style.scss";
 </style>

--- a/front-end/src/components/EditDocumentModalWindow/EditDocumentModalWindow.vue
+++ b/front-end/src/components/EditDocumentModalWindow/EditDocumentModalWindow.vue
@@ -221,9 +221,7 @@ export default {
 
         formData.append('category', this.form.currentCategory);
 
-        for (const tag of this.$refs.tagsInput.selected) {
-          formData.append('tags', tag);
-        }
+        this.$refs.tagsInput.selected.forEach(tag => formData.append('tags', tag));
 
         if (this.form.fileList.length !== 0) {
           if (this.ifFileChanged) {

--- a/front-end/src/components/EditDocumentModalWindow/EditDocumentModalWindow.vue
+++ b/front-end/src/components/EditDocumentModalWindow/EditDocumentModalWindow.vue
@@ -90,16 +90,7 @@
         </el-select>
       </el-form-item>
 
-      <el-form-item label="Ключевые слова">
-        <tags-input element-id="tags"
-                    v-model="form.selectedTags"
-                    :existing-tags="existingTags"
-                    :typeahead="true"
-                    placeholder="Добавить ключевое слово"
-                    :typeahead-hide-discard="true"
-                    class="add-tags">
-        </tags-input>
-      </el-form-item>
+      <TagsInput ref="tagsInput" label="Ключевые слова" :selected="document.tags" />
 
       <!--            <el-form-item>-->
       <!--                <div class="add-files">-->
@@ -145,16 +136,16 @@
 </template>
 
 <script>
-import {getExistingTags} from "../../api/existingTags";
-import axios from "axios";
 import moment from 'moment'
 import EventBus from '../EventBus';
 import {updateDocs} from "../../api/upload";
 import {mapState} from "vuex";
+import TagsInput from "@/components/Tags/TagsInput";
 
 
 export default {
   name: "EditDocumentModalWindow",
+  components: {TagsInput},
   data() {
     return {
       form: {
@@ -168,15 +159,10 @@ export default {
         newAuthorPatronymic: '',
         publisher: '',
         newPublisher: '',
-        selectedTags: [],
         fileList: [],
         currentCategory: ''
       },
       ifFileChanged: false,
-      existingTags: [
-        {key: 1, value: 'Стратегия'},
-        {key: 2, value: 'Тактика'},
-      ],
       publishers: [{name: 'Добавить новое', id: -1}, ...this.$store.getters.publishers],
     }
   },
@@ -185,9 +171,6 @@ export default {
       type: Object,
       required: true
     }
-  },
-  created() {
-    this.fetchData()
   },
   updated() {
     // console.log(this.form.fileList)
@@ -204,9 +187,6 @@ export default {
       newAuthorPatronymic: '',
       publisher: this.document.publishers[0].id,
       newPublisher: '',
-      selectedTags: this.document.tags.map(item => {
-        return {key: item, value: item}
-      }),
       fileList: [this.document.file],
       currentCategory: this.categories.find(item => {
         return item.id == this.document.category
@@ -220,14 +200,6 @@ export default {
     })
   },
   methods: {
-    fetchData() {
-      getExistingTags()
-          .then(tags => {
-            this.existingTags = tags
-          }).catch(() => {
-        console.log('Данные по тегам не указаны')
-      })
-    },
     onSubmit() {
       const self = this
       if (this.form.title !== '' && this.form.currentCategory !== '') {
@@ -249,7 +221,7 @@ export default {
 
         formData.append('category', this.form.currentCategory);
 
-        for (const tag of this.form.selectedTags.map(tag => tag.value)) {
+        for (const tag of this.$refs.tagsInput.selected) {
           formData.append('tags', tag);
         }
 

--- a/front-end/src/components/Tags/TagsInput.vue
+++ b/front-end/src/components/Tags/TagsInput.vue
@@ -1,0 +1,82 @@
+<template>
+  <el-form-item :label="label">
+    <el-tag
+        v-for="tag in selected"
+        :key="tag"
+        closable
+        @close="handleClose(tag)"
+        class="mr-2"
+    >
+      {{ tag }}
+    </el-tag>
+
+    <el-autocomplete
+        v-model="tag"
+        :fetch-suggestions="suggestions"
+        @select="handleSelect"
+        @keyup.enter.native="handleSelect"
+        class="inline-input"
+    ></el-autocomplete>
+  </el-form-item>
+</template>
+
+<script>
+import {getExistingTags} from "@/api/existingTags";
+
+export default {
+  name: "TagsInput",
+
+  props: {
+    label: {
+      type: String,
+      required: true,
+    },
+    selected: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  data() {
+    return {
+      tag: '',
+      all: [],
+    }
+  },
+
+  created() {
+    getExistingTags()
+      .then(response => {
+        this.all = response.data
+      })
+      .catch(error => {
+        console.log("Failed to fetch tags: ", error)
+      })
+  },
+
+  methods: {
+    handleSelect() {
+      const tag = this.tag.trim().toLowerCase()
+      if (this.tag && !this.selected.includes(tag)) {
+        this.selected.push(tag)
+      }
+      this.tag = ''
+    },
+
+    handleClose(tag) {
+      const index = this.selected.indexOf(tag)
+      if (index > -1) {
+        this.selected.splice(index, 1)
+      }
+    },
+
+    suggestions(text, cb) {
+      const asValues = this.all
+        .filter(tag => !this.selected.includes(tag))
+        .filter(tag => tag.indexOf(text.toLowerCase()) > -1)
+        .map(tag => ({value: tag}))
+      cb(asValues)
+    },
+  }
+}
+</script>

--- a/front-end/src/components/Tags/TagsInput.vue
+++ b/front-end/src/components/Tags/TagsInput.vue
@@ -71,10 +71,13 @@ export default {
     },
 
     suggestions(text, cb) {
+      // Two-step filter:
+      //   1. Filter tags that are not selected yet.
+      //   2. Leave the ones that contain tag as substring.
       const asValues = this.all
-        .filter(tag => !this.selected.includes(tag))
-        .filter(tag => tag.indexOf(text.toLowerCase()) > -1)
+        .filter(tag => !this.selected.includes(tag) && tag.indexOf(text.toLowerCase()) > -1)
         .map(tag => ({value: tag}))
+
       cb(asValues)
     },
   }

--- a/front-end/src/main.js
+++ b/front-end/src/main.js
@@ -1,7 +1,5 @@
 import Vue from 'vue'
-import VoerroTagsInput from '@voerro/vue-tagsinput';
 
-Vue.component('tags-input', VoerroTagsInput);
 import 'normalize.css/normalize.css' // A modern alternative to CSS resets
 import Multiselect from 'vue-multiselect'
 // register globally

--- a/front-end/src/styles/index.scss
+++ b/front-end/src/styles/index.scss
@@ -3,7 +3,6 @@
 @import './transition.scss';
 @import './element-ui.scss';
 @import './sidebar.scss';
-@import url('https://cdn.jsdelivr.net/npm/@voerro/vue-tagsinput@2.0.2/dist/style.css');
 
 @font-face {
   font-family: "ProximaNovaRegular";


### PR DESCRIPTION
This pull request aims to:
* Extract tag input logic into separate `TagsInput` component.
* Adjust modal components to use it.
* Resolve minor problems (remove unused import/functions, style formatting, etc.).

![image](https://user-images.githubusercontent.com/22966523/97602147-07f78300-1a1c-11eb-9e1b-1858cc983e84.png)

Should close #74.