### PR TITLE
Disable lint checks for too-many-arguments

### DIFF
--- a/back-end/src/dms/tests/conftest.py
+++ b/back-end/src/dms/tests/conftest.py
@@ -97,7 +97,7 @@ def user():
 
 @pytest.fixture
 def paper_data(file):
-
+    # pylint: disable=too-many-arguments
     def call_me(file_name: str = "filename",
                 file_content: str = "file content",
                 tags: List[str] = None,


### PR DESCRIPTION
Вisable lint checks for too-many-arguments in function paper_data